### PR TITLE
Start solving #1

### DIFF
--- a/src/main/kotlin/io/github/phenax/h/AbstractView.kt
+++ b/src/main/kotlin/io/github/phenax/h/AbstractView.kt
@@ -10,7 +10,7 @@ abstract class AbstractView {
 	// Renders the dom node that is returned
 	abstract fun render(): DOMNode
 
-	open protected fun _render(): DOMNode = render()
+	protected open fun _render(): DOMNode = render()
 
 	// Render to node and html methods
 	fun renderToNode(): DOMNode = _render()
@@ -19,22 +19,32 @@ abstract class AbstractView {
 
 	// Html node shorthand
 	fun h(
-		nodeName: String,
-		props: Map<String, String>?,
-		children: List<DOMNode>?,
-		isClosingTagRequired: Boolean = true
+            nodeName: String,
+            props: Map<String, String>?,
+            children: List<DOMNode>?,
+            isClosingTagRequired: Boolean = true
 	): DOMNode {
 		return HtmlNode(nodeName, props, children, isClosingTagRequired)
+	}
+
+	// Inline html node shorthand
+	fun ih(
+			nodeName: String,
+			props: Map<String, String>?,
+			children: List<InlineDOMNode>?,
+			isClosingTagRequired: Boolean = true
+	): InlineDOMNode {
+		return InlineHtmlNode(nodeName, props, children, isClosingTagRequired)
 	}
 
 	// Mount a custom component
 	fun h(component: Component): DOMNode = component.render()
 
 	// Text node shorthand
-	fun text(text: String): DOMNode = TextNode(text)
+	fun text(text: String): InlineDOMNode = TextNode(text)
 
 	// Unsafe Text node shorthand
-	fun unsafeText(text: String): DOMNode = TextNode(text, false)
+	fun unsafeText(text: String): InlineDOMNode = TextNode(text, false)
 
 	// File node shorthand
 	fun file(text: String, loadOnCreate: Boolean): DOMNode = FileNode(text, loadOnCreate)
@@ -43,7 +53,7 @@ abstract class AbstractView {
 
 
 
-	/* Node creation shorthands */
+	/* Block node creation shorthands */
 
 	fun html(props: Map<String, String>?, children: List<DOMNode>?): DOMNode = h("html", props, children)
 	fun body(props: Map<String, String>?, children: List<DOMNode>?): DOMNode = h("body", props, children)
@@ -57,6 +67,12 @@ abstract class AbstractView {
 	fun h6(props: Map<String, String>?, children: List<DOMNode>?): DOMNode = h("h6", props, children)
 	fun p(props: Map<String, String>?, children: List<DOMNode>?): DOMNode = h("p", props, children)
 
+	/* Inline node creation shorthands */
+
+	fun a(props: Map<String, String>?, children: List<InlineDOMNode>?): InlineDOMNode = ih("a", props, children)
+	fun em(props: Map<String, String>?, children: List<InlineDOMNode>?): InlineDOMNode = ih("em", props, children)
+	fun strong(props: Map<String, String>?, children: List<InlineDOMNode>?): InlineDOMNode = ih("strong", props, children)
+
 	/* ## Common case shorthands ## */
 
 	fun h1(props: Map<String, String>?, content: String): DOMNode = h1(props, listOf( text(content) ))
@@ -66,6 +82,12 @@ abstract class AbstractView {
 	fun h5(props: Map<String, String>?, content: String): DOMNode = h5(props, listOf( text(content) ))
 	fun h6(props: Map<String, String>?, content: String): DOMNode = h6(props, listOf( text(content) ))
 	fun p(props: Map<String, String>?, content: String): DOMNode = p(props, listOf( text(content) ))
+
+	fun a(props: Map<String, String>?, content: String): InlineDOMNode = a(props, listOf( text(content) ))
+	fun em(props: Map<String, String>?, content: String): InlineDOMNode = em(props, listOf( text(content) ))
+	fun em(content: String): InlineDOMNode = em(null, content)
+	fun strong(props: Map<String, String>?, content: String): InlineDOMNode = strong(props, listOf( text(content) ))
+	fun strong(content: String): InlineDOMNode = strong(null, content)
 
 	// Render external stylesheet (link tag)
 	fun style(href: String, props: Map<String, String> = mapOf<String, String>()): DOMNode {

--- a/src/main/kotlin/io/github/phenax/h/AnonymousComponent.kt
+++ b/src/main/kotlin/io/github/phenax/h/AnonymousComponent.kt
@@ -1,12 +1,12 @@
 package io.github.phenax.h
 
-import io.github.phenax.h.node.DOMNode
 import io.github.phenax.h.layouts.EmptyLayout
+import io.github.phenax.h.node.DOMNode
 
 // Anonymous component
 class AnonymousComponent(
-	val _getRenderNode: (d: AnonymousComponent) -> DOMNode,
-	override val layout: Layout = EmptyLayout()
+        val _getRenderNode: (d: AnonymousComponent) -> DOMNode,
+        override val layout: Layout = EmptyLayout()
 ): Component() {
 
 	// Render node

--- a/src/main/kotlin/io/github/phenax/h/Component.kt
+++ b/src/main/kotlin/io/github/phenax/h/Component.kt
@@ -10,7 +10,7 @@ abstract class Component: AbstractView() {
 	// Layout to wrap the component (view.layout.EmptyLayout for no wrapper)
 	abstract val layout: Layout
 
-	override protected fun _render(): DOMNode {
+	override fun _render(): DOMNode {
 
 		// Render component inside wrapper
 		return layout.render(this)

--- a/src/main/kotlin/io/github/phenax/h/layouts/EmptyLayout.kt
+++ b/src/main/kotlin/io/github/phenax/h/layouts/EmptyLayout.kt
@@ -1,7 +1,7 @@
 package io.github.phenax.h.layouts
 
-import io.github.phenax.h.Layout
 import io.github.phenax.h.Component
+import io.github.phenax.h.Layout
 import io.github.phenax.h.node.DOMNode
 
 class EmptyLayout: Layout() {

--- a/src/main/kotlin/io/github/phenax/h/node/AbstractDOMNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/AbstractDOMNode.kt
@@ -1,0 +1,9 @@
+package io.github.phenax.h.node
+
+/**
+ * DOM node for templating html stuff
+ */
+abstract class AbstractDOMNode : DOMNode {
+
+	override fun toString() = toHtml()
+}

--- a/src/main/kotlin/io/github/phenax/h/node/DOMNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/DOMNode.kt
@@ -1,12 +1,6 @@
 package io.github.phenax.h.node
 
-/**
- * DOM node for templating html stuff
- */
-abstract class DOMNode {
-
-	// Convert the node to html string for rendering
-	abstract fun toHtml(): String
-
-	override fun toString() = toHtml()
+interface DOMNode {
+    // Convert the node to html string for rendering
+    fun toHtml(): String
 }

--- a/src/main/kotlin/io/github/phenax/h/node/EmptyNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/EmptyNode.kt
@@ -1,6 +1,6 @@
 package io.github.phenax.h.node
 
 // Render nothing
-class EmptyNode: DOMNode() {
+class EmptyNode: AbstractDOMNode(), InlineDOMNode {
 	override fun toHtml(): String = ""
 }

--- a/src/main/kotlin/io/github/phenax/h/node/FileNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/FileNode.kt
@@ -8,7 +8,7 @@ import java.io.File
  * @param filePath        Path to the file to read
  * @param loadOnCreate    If true, loads the file into memory when initiated
  */
-class FileNode(val filePath: String, val loadOnCreate: Boolean): DOMNode() {
+class FileNode(val filePath: String, val loadOnCreate: Boolean): AbstractDOMNode() {
 
 	// Loaded file contents
 	private val _fileContents = if(loadOnCreate) _readFile() else ""

--- a/src/main/kotlin/io/github/phenax/h/node/HtmlNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/HtmlNode.kt
@@ -9,19 +9,19 @@ package io.github.phenax.h.node
  * @param children                Child nodes
  * @param isClosingTagRequired    Does it require a closing tag
  */
-class HtmlNode(
-	val nodeName: String,
-	val props: Map<String, String>? = null,
-	val children: List<DOMNode>? = null,
-	val isClosingTagRequired: Boolean = true
-): DOMNode() {
+open class HtmlNode(
+		val nodeName: String,
+		val props: Map<String, String>? = null,
+		val children: List<DOMNode>? = null,
+		val isClosingTagRequired: Boolean = true
+): AbstractDOMNode() {
 
 	override fun toHtml(): String {
 
 		// Properties map to string
 		var propsString =
 			props?.map({ "${it.key}=\"${it.value}\"" })?.joinToString(" ")
-		propsString = if(propsString != null) " $propsString" else ""
+		propsString = if(!propsString.isNullOrEmpty()) " $propsString" else ""
 
 		if(isClosingTagRequired) {
 

--- a/src/main/kotlin/io/github/phenax/h/node/InlineDOMNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/InlineDOMNode.kt
@@ -1,0 +1,7 @@
+package io.github.phenax.h.node
+
+/**
+ * A DOM node that doesn't contain any block elements, and thus can go inside an inline element.
+ */
+interface InlineDOMNode : DOMNode {
+}

--- a/src/main/kotlin/io/github/phenax/h/node/InlineHtmlNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/InlineHtmlNode.kt
@@ -1,0 +1,9 @@
+package io.github.phenax.h.node
+
+class InlineHtmlNode(
+        nodeName: String,
+        props: Map<String, String>?,
+        children: List<InlineDOMNode>?,
+        isClosingTagRequired: Boolean)
+    : HtmlNode(nodeName, props, children, isClosingTagRequired), InlineDOMNode {
+}

--- a/src/main/kotlin/io/github/phenax/h/node/TextNode.kt
+++ b/src/main/kotlin/io/github/phenax/h/node/TextNode.kt
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.StringEscapeUtils
  * 
  * @param text  The string to render
  */
-class TextNode(val text: String, val isSafe: Boolean = true): DOMNode() {
+class TextNode(val text: String, val isSafe: Boolean = true): AbstractDOMNode(), InlineDOMNode {
 
 	override fun toHtml(): String {
 

--- a/src/test/kotlin/io/github/phenax/h/ComponentSpec.kt
+++ b/src/test/kotlin/io/github/phenax/h/ComponentSpec.kt
@@ -1,10 +1,6 @@
 package io.github.phenax.h
 
-import io.kotlintest.matchers.*
-import io.kotlintest.properties.*
-import io.kotlintest.*
-
-import io.github.phenax.h.node.DOMNode
+import io.kotlintest.matchers.shouldBe
 
 class ComponentSpec: MySpec() {
 
@@ -60,7 +56,7 @@ class ComponentSpec: MySpec() {
 							),
 							p(
 								mapOf( "class" to "card--description" ),
-								listOf( text("Card description") )
+								listOf( text("Card description"), em("with emphasis") )
 							)
 						)
 					)
@@ -70,7 +66,7 @@ class ComponentSpec: MySpec() {
 					"""
 						|<div class="card">
 							|<h1 class="card--title">Card title</h1>
-							| <p class="card--description">Card description</p>
+							| <p class="card--description">Card description <em>with emphasis</em></p>
 						|</div>
 					""".trimMargin().replace("\n", "")
 

--- a/src/test/kotlin/io/github/phenax/h/LayoutSpec.kt
+++ b/src/test/kotlin/io/github/phenax/h/LayoutSpec.kt
@@ -1,13 +1,6 @@
 package io.github.phenax.h
 
-import io.kotlintest.matchers.*
-import io.kotlintest.properties.*
-import io.kotlintest.*
-
-import io.github.phenax.h.Component
-import io.github.phenax.h.node.DOMNode
-import io.github.phenax.h.helpers.MyLayout
-import io.github.phenax.h.layouts.EmptyLayout
+import io.kotlintest.matchers.shouldBe
 
 class LayoutSpec: MySpec() {
 

--- a/src/test/kotlin/io/github/phenax/h/MySpec.kt
+++ b/src/test/kotlin/io/github/phenax/h/MySpec.kt
@@ -1,12 +1,10 @@
 package io.github.phenax.h
 
-import io.kotlintest.specs.ShouldSpec
-import io.kotlintest.*
-
-import io.github.phenax.h.Component
-import io.github.phenax.h.Layout
-import io.github.phenax.h.node.DOMNode
 import io.github.phenax.h.helpers.MyLayout
+import io.github.phenax.h.node.DOMNode
+import io.kotlintest.TestCaseConfig
+import io.kotlintest.TestCaseContext
+import io.kotlintest.specs.ShouldSpec
 
 
 abstract class MySpec(


### PR DESCRIPTION
Adds type checking that ensures inline elements can't contain block elements. Since this requires a type hierarchy that's not a tree, DOMNode becomes an interface.
Adds methods for a, em, strong tags.
Eliminates space at end of tag if a property map is passed in but is empty.